### PR TITLE
handle scope changes

### DIFF
--- a/lib/schema-to-endpoints.js
+++ b/lib/schema-to-endpoints.js
@@ -16,6 +16,7 @@ function schemaToEndpoints(schema) {
           const renamedEndpoint = Object.assign(
             definitionToEndpoint({ method, url }, definition),
             {
+              scope: change.before.operationId.split("/")[0],
               id: change.before.operationId.split("/")[1],
               renamed: {
                 before: {


### PR DESCRIPTION
When sending this query

```graphql
{
  endpoints(
    version: "26.17.1"
    route: "DELETE /applications/{client_id}/grants/{access_token}"
  ) {
    name
    scope(format: CAMELCASE)
    id(format: CAMELCASE)
    method
    url
    isDeprecated
    changes {
      before {
        operationId
        type
      }
    }
  }
}
```

Before, the response was

```json
{
  "data": {
    "endpoints": [
      {
        "name": "Revoke a grant for an application",
        "scope": "apps",
        "id": "revokeGrantForApplication",
        "method": "DELETE",
        "url": "/applications/{client_id}/grants/{access_token}"
      },
      {
        "name": "Revoke a grant for an application",
        "scope": "apps",
        "id": "revokeGrantForApplication",
        "method": "DELETE",
        "url": "/applications/{client_id}/grants/{access_token}"
      }
    ]
  }
}
```

Now it is

```json
{
  "data": {
    "endpoints": [
      {
        "name": "Revoke a grant for an application",
        "scope": "apps",
        "id": "revokeGrantForApplication",
        "method": "DELETE",
        "url": "/applications/{client_id}/grants/{access_token}"
      },
      {
        "name": "Revoke a grant for an application",
        "scope": "oauthAuthorizations",
        "id": "revokeGrantForApplication",
        "method": "DELETE",
        "url": "/applications/{client_id}/grants/{access_token}"
      }
    ]
  }
}
```

Note `"scope": "oauthAuthorizations"` in the 2nd item